### PR TITLE
Optimize day 1

### DIFF
--- a/src/bin/day01.rs
+++ b/src/bin/day01.rs
@@ -47,7 +47,7 @@ mod tests {
 
     #[test]
     fn test_part1() {
-        assert_eq!(1602, part1(INPUT));
+        assert_eq!(part1(INPUT), 1602);
     }
 
     #[test]
@@ -57,6 +57,6 @@ mod tests {
 
     #[test]
     fn test_part2() {
-        assert_eq!(1633, part2(INPUT));
+        assert_eq!(part2(INPUT), 1633);
     }
 }

--- a/src/bin/day01.rs
+++ b/src/bin/day01.rs
@@ -1,7 +1,9 @@
 use aoc2021::prelude::*;
 
-fn count_incrementing_windows(window_size: usize) -> usize {
-    let measurements = read_lines_as::<i64>("inputs/day01.txt");
+const INPUT: &'static str = include_str!("../../inputs/day01.txt");
+
+fn count_incrementing_windows(input: &str, window_size: usize) -> usize {
+    let measurements = parse_lines_as::<i64>(input);
 
     measurements
         .windows(window_size + 1)
@@ -9,30 +11,52 @@ fn count_incrementing_windows(window_size: usize) -> usize {
         .count()
 }
 
-fn part1() -> usize {
-    count_incrementing_windows(1)
+fn part1(input: &str) -> usize {
+    count_incrementing_windows(input, 1)
 }
 
-fn part2() -> usize {
-    count_incrementing_windows(3)
+fn part2(input: &str) -> usize {
+    count_incrementing_windows(input, 3)
 }
 
 fn main() {
-    dbg!(part1());
-    dbg!(part2());
+    dbg!(part1(INPUT));
+    dbg!(part2(INPUT));
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    const SAMPLE_INPUT: &'static str = "199
+200
+208
+210
+200
+207
+240
+269
+260
+263
+";
+
+    #[test]
+    fn test_part1_sample() {
+        assert_eq!(part1(SAMPLE_INPUT), 7);
+    }
+
     #[test]
     fn test_part1() {
-        assert_eq!(1602, part1());
+        assert_eq!(1602, part1(INPUT));
+    }
+
+    #[test]
+    fn test_part2_sample() {
+        assert_eq!(part2(SAMPLE_INPUT), 5);
     }
 
     #[test]
     fn test_part2() {
-        assert_eq!(1633, part2());
+        assert_eq!(1633, part2(INPUT));
     }
 }

--- a/src/bin/day01.rs
+++ b/src/bin/day01.rs
@@ -2,22 +2,11 @@ use aoc2021::prelude::*;
 
 fn count_incrementing_windows(window_size: usize) -> usize {
     let measurements = read_lines_as::<i64>("inputs/day01.txt");
-    let mut windows = measurements.windows(window_size);
 
-    let mut prev_sum: i64 = windows.next().unwrap().iter().sum();
-    let mut incr_cnt = 0;
-
-    for window in windows {
-        let window_sum = window.iter().sum();
-
-        if window_sum > prev_sum {
-            incr_cnt += 1;
-        }
-
-        prev_sum = window_sum;
-    }
-
-    incr_cnt
+    measurements
+        .windows(window_size + 1)
+        .filter(|window| window.last().unwrap() > window.first().unwrap())
+        .count()
 }
 
 fn part1() -> usize {

--- a/src/bin/day01.rs
+++ b/src/bin/day01.rs
@@ -3,7 +3,7 @@ use aoc2021::prelude::*;
 const INPUT: &'static str = include_str!("../../inputs/day01.txt");
 
 fn count_incrementing_windows(input: &str, window_size: usize) -> usize {
-    let measurements = parse_lines_as::<i64>(input);
+    let measurements = parse_lines::<i64>(input);
 
     measurements
         .windows(window_size + 1)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@ pub mod prelude {
     use std::fmt::Debug;
     use std::str::FromStr;
 
-    pub fn parse_lines_as<T: FromStr>(raw_lines: &str) -> Vec<T>
+    pub fn parse_lines<T: FromStr>(raw_lines: &str) -> Vec<T>
     where
         <T as FromStr>::Err: Debug,
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,12 +2,11 @@ pub mod prelude {
     use std::fmt::Debug;
     use std::str::FromStr;
 
-    pub fn read_lines_as<T: FromStr>(fpath: &str) -> Vec<T>
+    pub fn parse_lines_as<T: FromStr>(raw_lines: &str) -> Vec<T>
     where
         <T as FromStr>::Err: Debug,
     {
-        std::fs::read_to_string(fpath)
-            .unwrap()
+        raw_lines
             .lines()
             .map(|s| s.parse().unwrap())
             .collect::<Vec<T>>()


### PR DESCRIPTION
The idea: given that we're comparing sums of *overlapping* windows, the elements of two neighbor windows will be the same *except* for the first element of the first window, and the last element of the second window.

Say we have a sequence: `A B C D`. Given a window size of `3`, we have the following windows:

```
A B C
B C D
```

In the naive solution, we would simply sum up each window separately and compare the two. However, given that `B C` are present in both windows, including those values in the comparison is unnecessary. Instead, we can use a window size of `4` (or `N + 1`) and compare the last and first elements (`D > A`) to determine whether the sum of the  second window is greater than the first.